### PR TITLE
ci(KAP-2): Removing unnecessary Dockerfile and including shell script in assets

### DIFF
--- a/.github/workflows/kapzuul.yaml
+++ b/.github/workflows/kapzuul.yaml
@@ -27,4 +27,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: kapzuul_debian11_amd64
+          files: |
+            kapzuul_debian11_amd64
+            install-kapzuul.sh


### PR DESCRIPTION
This PR removes an empty Dockerfile that was committed and also include the shell script in the assets for clients to download.