### PR TITLE
fix(KAP-2): fixing typo in install script

### DIFF
--- a/install-kapzuul.sh
+++ b/install-kapzuul.sh
@@ -21,4 +21,4 @@ apt-get update
 # Install docker
 apt-get install -y docker-ce docker-ce-cli containerd.io
 
-wget -o /usr/sbin/kapzuul https://github.com/kapzuul/kapzuul/releases/latest/download/kapzuul_debian11_amd64
+wget -O /usr/sbin/kapzuul https://github.com/kapzuul/kapzuul/releases/latest/download/kapzuul_debian11_amd64


### PR DESCRIPTION
This PR fixes an issue with the install script which had a lowercase instead of uppercase O in the `wget` command.