### PR TITLE
fix(KAP-2): improving formatting on version, and adding chmod to install script

### DIFF
--- a/cmd/kapzuul/version.go
+++ b/cmd/kapzuul/version.go
@@ -13,7 +13,7 @@ func versionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "The version of this binary",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Print(version, gitSha, "\n")
+			fmt.Print(version, " ", gitSha, "\n")
 		},
 	}
 	return cmd

--- a/install-kapzuul.sh
+++ b/install-kapzuul.sh
@@ -22,3 +22,4 @@ apt-get update
 apt-get install -y docker-ce docker-ce-cli containerd.io
 
 wget -O /usr/sbin/kapzuul https://github.com/kapzuul/kapzuul/releases/latest/download/kapzuul_debian11_amd64
+chmod +x /usr/sbin/kapzuul


### PR DESCRIPTION
THis PR adds some spacing to the `version` command to improve readability and adds a chmod +x to the install script so that the `kapzuul` command is executable.
